### PR TITLE
Added the entire object advertisement  to the parser-ibeacon output

### DIFF
--- a/lib/parser-ibeacon.js
+++ b/lib/parser-ibeacon.js
@@ -34,6 +34,7 @@ BeaconParserIbeacon.prototype.parse = function(peripheral) {
 	].join('-').toUpperCase();
 
 	return {
+		advertisement : ad,
 		uuid : uuid,
 		major: manu.slice(20, 22).readUInt16BE(0),
 		minor: manu.slice(22, 24).readUInt16BE(0),


### PR DESCRIPTION
to read the battery status of different manufacturers (SKYLAB - advertisement.serviceData[0].uuid.slice(2) in HEX, WELLCORE - advertisement.serviceData[0].data[6] in DEC)